### PR TITLE
Update tag ref for 5 ZenPacks. Dedupe Windows.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,7 @@
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoMonitor", 
-            "ref": "5.3.1"
+            "ref": "5.3.3"
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.MultiRealmIP": {
             "repo": "zenoss/ZenPacks.zenoss.MultiRealmIP", 
@@ -75,7 +75,7 @@
         }, 
         "zenpacks/ZenPacks.zenoss.Microsoft.Windows": {
             "repo": "zenoss/ZenPacks.zenoss.Microsoft.Windows", 
-            "ref": "2.2.1"
+            "ref": "2.3.1"
         }, 
         "core": {
             "repo": "zenoss/zenoss-prodbin", 
@@ -95,7 +95,7 @@
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoUCS": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoUCS", 
-            "ref": "1.9.1"
+            "ref": "1.9.2"
         }, 
         "zenpacks/ZenPacks.zenoss.FtpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.FtpMonitor", 
@@ -111,7 +111,7 @@
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.ZenWebTx": {
             "repo": "zenoss/ZenPacks.zenoss.ZenWebTx", 
-            "ref": "2.9.1"
+            "ref": "2.9.2"
         }, 
         "zenpacks/ZenPacks.zenoss.ControlCenter": {
             "repo": "zenoss/ZenPacks.zenoss.ControlCenter", 
@@ -155,7 +155,7 @@
         }, 
         "zenpacks/ZenPacks.zenoss.MySqlMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.MySqlMonitor", 
-            "ref": "3.0.4"
+            "ref": "3.0.5"
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.RANCIDIntegrator": {
             "repo": "zenoss/ZenPacks.zenoss.RANCIDIntegrator", 
@@ -266,10 +266,6 @@
         "zenpacks/ZenPacks.zenoss.LinuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.LinuxMonitor", 
             "ref": "1.3.0"
-        }, 
-        "enterprise_zenpacks/ZenPacks.zenoss.Microsoft.Windows": {
-            "repo": "zenoss/ZenPacks.zenoss.Microsoft.Windows", 
-            "ref": "2.2.1"
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.ZenDeviceACL": {
             "repo": "zenoss/ZenPacks.zenoss.ZenDeviceACL", 


### PR DESCRIPTION
* CiscoMonitor: 5.3.1 -> 5.3.3
* CiscoUCS: 1.9.1 -> 1.9.2
* Microsoft.Windows: 2.2.1 -> 2.3.1
* MySqlMonitor: 3.0.4 -> 3.0.5
* ZenWebTx: 2.9.1 -> 2.9.2

Microsoft.Windows had two entries. One under zenpacks/ and another under
enterprise_zenpacks/. Removed the enterprise_zenpacks/ entry because it
is an open source ZenPack.