### PR TITLE
Update CiscoMonitor from 5.3.3 to 5.3.4.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,7 @@
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoMonitor", 
-            "ref": "5.3.3"
+            "ref": "5.3.4"
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.MultiRealmIP": {
             "repo": "zenoss/ZenPacks.zenoss.MultiRealmIP", 


### PR DESCRIPTION
* Fix "Unable to cleanup" warning on first install. (ZEN-16895)
* Fix VRF relationship for FastEthernet interfaces. (ZEN-16896)