### PR TITLE
Use master branch of EnterpriseLinux on develop.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,7 +38,7 @@
         }, 
         "enterprise_zenpacks/ZenPacks.zenoss.EnterpriseLinux": {
             "repo": "zenoss/ZenPacks.zenoss.EnterpriseLinux", 
-            "ref": "develop"
+            "ref": "master"
         }, 
         "zenpacks/ZenPacks.zenoss.DigMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.DigMonitor", 


### PR DESCRIPTION
EnterpriseLinux's functionality is being merged into LinuxMonitor. To
prevent breaking develop build we need to make sure that EnterpriseLinux
and LinuxMonitor are both being built from the same branch.

Fixes ZEN-21606.