### PR TITLE
Add CalculatedPerformance ZenPack to 5.0.x manifest.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -295,7 +295,7 @@
             "repo": "zenoss/ZenPacks.zenoss.ZenPOP3",
             "ref": "support/5.0.x"
         },
-		"zenpacks/ZenPacks.zenoss.CalculatedPerformance": {
+        "zenpacks/ZenPacks.zenoss.CalculatedPerformance": {
             "repo": "zenoss/ZenPacks.zenoss.CalculatedPerformance",
             "ref": "2.2.0"
         }

--- a/manifest.json
+++ b/manifest.json
@@ -294,6 +294,10 @@
         "zenpacks/ZenPacks.zenoss.ZenPOP3": {
             "repo": "zenoss/ZenPacks.zenoss.ZenPOP3",
             "ref": "support/5.0.x"
+        },
+		"zenpacks/ZenPacks.zenoss.CalculatedPerformance": {
+            "repo": "zenoss/ZenPacks.zenoss.CalculatedPerformance",
+            "ref": "2.2.0"
         }
     }
 }


### PR DESCRIPTION
This ZenPack is needed because the NetAppMonitor (v3.3) zenpack now has a dependency on the CalculatedPerformance zenpack.