### PR TITLE
Upgrade Windows ZenPack to 2.5.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -71,7 +71,7 @@
         },
         "zenpacks/ZenPacks.zenoss.Microsoft.Windows": {
             "repo": "zenoss/ZenPacks.zenoss.Microsoft.Windows",
-            "ref": "2.5.7"
+            "ref": "2.5.8"
         },
         "core": {
             "repo": "zenoss/zenoss-prodbin",


### PR DESCRIPTION
Microsoft.Windows 2.5.8 uncludes the following changes:

* Windows Shell datasource passes severity to parsers. (ZEN-21928)