### PR TITLE
Upgrade EMC ZenPack to 1.1.2.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -229,7 +229,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.EMC.base": {
             "repo": "zenoss/ZenPacks.zenoss.EMC.base",
-            "ref": "1.1.0"
+            "ref": "1.1.2"
         },
         "zenpacks/ZenPacks.zenoss.LinuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.LinuxMonitor",


### PR DESCRIPTION
EMC.base 1.1.2 includes the following changes:

* Remove dependency on CalculatedPerformance ZenPack. (ZEN-19707)
* Fix incorrect data device (LUN) impacts. (ZEN-21813)