### PR TITLE
(5.1.x) Update CiscoUCS ZenPack: 2.3.2 to 2.3.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -87,7 +87,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoUCS": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoUCS",
-            "ref": "2.3.2"
+            "ref": "2.3.4"
         },
         "zenpacks/ZenPacks.zenoss.FtpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.FtpMonitor",


### PR DESCRIPTION
Changes from 2.3.2 to 2.3.4:

- Fix re-opening of events when UCS deletes them. (ZEN-22420)
- Fix potential Impact modeling performance issue.

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.3.2...2.3.4