### PR TITLE
(5.1.x) Update CiscoMonitor ZenPack: 5.6.2 to 5.6.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoMonitor",
-            "ref": "5.6.2"
+            "ref": "5.6.3"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.MultiRealmIP": {
             "repo": "zenoss/ZenPacks.zenoss.MultiRealmIP",


### PR DESCRIPTION
Changes from 5.6.2 to 5.6.3:

- Indicate NX-API for Nexus 9000 in Add Infrastructure Wizard.
  (ZEN-21165)
- Associate cefcPowerStatusChange events with Ethernet interfaces.
  (ZEN-21726)

https://github.com/zenoss/ZenPacks.zenoss.CiscoMonitor/compare/5.6.2...5.6.3