### PR TITLE
(develop) Add NetScaler ZenPack to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -197,6 +197,10 @@
             "repo": "zenoss/zenoss.metric.consumer", 
             "ref": "develop"
         }, 
+        "enterprise_zenpacks/ZenPacks.zenoss.NetScaler": {
+            "repo": "zenoss/ZenPacks.zenoss.NetScaler", 
+            "ref": "master"
+        }, 
         "enterprise_zenpacks/ZenPacks.zenoss.NetScreenMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.NetScreenMonitor", 
             "ref": "master"


### PR DESCRIPTION
This doesn't do much by itself. There'll be a corresponding update to
platform-build to cause NetScaler to be built, packaged, but not
installed by default.