### PR TITLE
(5.1.x) Add NetScaler ZenPack to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -125,6 +125,10 @@
             "repo": "control-center/serviced",
             "ref": "support/1.1.x"
         },
+        "enterprise_zenpacks/ZenPacks.zenoss.NetScaler": {
+            "repo": "zenoss/ZenPacks.zenoss.NetScaler",
+            "ref": "1.0.6"
+        },
         "enterprise_zenpacks/ZenPacks.zenoss.NetScreenMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.NetScreenMonitor",
             "ref": "2.2.0"


### PR DESCRIPTION
This doesn't do much by itself. There'll be a corresponding update to
platform-build to cause NetScaler to be built, package, but not
installed by default.

See 461efb5 for the develop version of this change.