### PR TITLE
(5.1.x) Update AixMonitor ZenPack: 2.0.1 -> 2.2.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -269,7 +269,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.AixMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.AixMonitor",
-            "ref": "2.0.1"
+            "ref": "2.2.0"
         },
         "zproxy": {
             "repo": "zenoss/zproxy",


### PR DESCRIPTION
Changes from 2.0.1 to 2.2.0:

- Fix excessive remote command execution (ZEN-16740)
- IP Service modeling no longer ignoring zIpServiceMapMaxPort
  (ZEN-17360)
- Fix incorrect ssCpuIdle alias for multi-core systems (ZEN-17360)
- Fix handling of European date formats (ZEN-19089)
- Fix incorrect template bindings (ZEN-20078)
- Fix incorrect modeling time (ZEN-22127)
- Add/revise custom component icons, fix icon positioning (ZEN-22191,
  ZEN-22294)
- Fix missing Impact YAML file (ZEN-22250)
- Fixed missing graph datapoints (ZEN-22259)

https://github.com/zenoss/ZenPacks.zenoss.AixMonitor/compare/2.0.1..2.2.0