### PR TITLE
(5.1.x) Update NetAppMonitor ZenPack: 3.3.0 to 3.3.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -213,7 +213,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.NetAppMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.NetAppMonitor",
-            "ref": "3.3.0"
+            "ref": "3.3.1"
         },
         "metric-service": {
             "repo": "zenoss/query",


### PR DESCRIPTION
Changes from 3.3.0 to 3.3.1:

- Fixes ZEN-22440 (UTF8 monitoring issue)

https://github.com/zenoss/ZenPacks.zenoss.NetAppMonitor/compare/3.3.0...3.3.1