### PR TITLE
(5.1.x) Update PythonCollector ZenPack: 1.7.3 to 1.7.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         },
         "zenpacks/ZenPacks.zenoss.PythonCollector": {
             "repo": "zenoss/ZenPacks.zenoss.PythonCollector",
-            "ref": "1.7.3"
+            "ref": "1.7.4"
         },
         "zep": {
             "repo": "zenoss/zenoss-zep",


### PR DESCRIPTION
Changes from 1.7.3 to 1.7.4:

- Increase default blockingtimeout from 5 to 30 seconds. (ZEN-22632)
- Enable all plugins if blockingtimeout is set to 0. (ZEN-22633)

https://github.com/zenoss/ZenPacks.zenoss.PythonCollector/compare/1.7.3...1.7.4