### PR TITLE
(5.1.x) Update AixMonitor ZenPack: 2.2.0 to 2.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -273,7 +273,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.AixMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.AixMonitor",
-            "ref": "2.2.0"
+            "ref": "2.2.1"
         },
         "zproxy": {
             "repo": "zenoss/zproxy",


### PR DESCRIPTION
Changes from 2.2.0 to 2.2.1:

- Updated zenpacklib.py to address modeler timeouts from
  attribute-indexed components

https://github.com/zenoss/ZenPacks.zenoss.AixMonitor/compare/2.2.0...2.2.1