### PR TITLE
(5.1.x) Update BigIpMonitor ZenPack: 2.6.4 to 2.7.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.BigIpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.BigIpMonitor",
-            "ref": "2.6.4"
+            "ref": "2.7.0"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.EnterpriseSkin": {
             "repo": "zenoss/ZenPacks.zenoss.EnterpriseSkin",


### PR DESCRIPTION
Changes from 2.6.4 to 2.7.0:

- Conversion to ZPL
- Updated F5 MIBs
- Fixed MIB conflict issues for independently loaded MIBs
- Added Event Class Instances for all SNMP notifications including
- correlations
- Integration with Service Impact
- Added Icons for Service Impact/Dynamic View
- Additional monitoring for PowerSupply
- Revised/corrected datapoint types within RRD Templates
- Improved device resource modeling for memory (host vs. TMM) and swap
- Fixed numerous modeler issues
- Improved Zenoss 5.x compatibility

https://github.com/zenoss/ZenPacks.zenoss.BigIpMonitor/compare/2.6.4...2.7.0