### PR TITLE
(5.1.x) Update Microsoft.Windows ZenPack: 2.5.12 to 2.5.13

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -71,7 +71,7 @@
         },
         "zenpacks/ZenPacks.zenoss.Microsoft.Windows": {
             "repo": "zenoss/ZenPacks.zenoss.Microsoft.Windows",
-            "ref": "2.5.12"
+            "ref": "2.5.13"
         },
         "core": {
             "repo": "zenoss/zenoss-prodbin",


### PR DESCRIPTION
Changes from 2.5.12 to 2.5.13:

- Fix Active Directory not correctly detected (ZEN-23137)

https://github.com/zenoss/ZenPacks.zenoss.Microsoft.Windows/compare/2.5.12...2.5.13