### PR TITLE
(5.1.x) Update PredictiveThreshold ZenPack: 1.1.0 to 1.1.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -321,7 +321,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.PredictiveThreshold": {
             "repo": "zenoss/ZenPacks.zenoss.PredictiveThreshold",
-            "ref": "1.1.0"
+            "ref": "1.1.1"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoUCSCentral": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoUCSCentral",


### PR DESCRIPTION
Changes from 1.1.0 to 1.1.1:

- Fix issue caused by evaluationThreshold being string instead of
  integer. (ZEN-23328)

https://github.com/zenoss/ZenPacks.zenoss.PredictiveThreshold/compare/1.1.0...1.1.1