### PR TITLE
(5.1.x) Update UCSCapacity ZenPack: 1.2.1 to 1.2.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -301,7 +301,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.UCSCapacity": {
             "repo": "zenoss/ZenPacks.zenoss.UCSCapacity",
-            "ref": "1.2.1"
+            "ref": "1.2.2"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.PortalIntegration": {
             "repo": "zenoss/ZenPacks.zenoss.PortalIntegration",


### PR DESCRIPTION
Changes from 1.2.1 to 1.2.2:

- Fix issue caused by bad evaluationThreshold configuration on
  predictive thresholds. (ZEN-23328)

https://github.com/zenoss/ZenPacks.zenoss.UCSCapacity/compare/1.2.1...1.2.2