### PR TITLE
ZEN-23669 - update NFVI to use CC ZP 1.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -133,7 +133,7 @@
         },
         "zenpacks/ZenPacks.zenoss.ControlCenter": {
             "repo": "zenoss/ZenPacks.zenoss.ControlCenter",
-            "ref": "1.2.0"
+            "ref": "1.2.1"
         },
         "zenpacks/ZenPacks.zenoss.LinuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.LinuxMonitor",


### PR DESCRIPTION
ZEN-23669 - update NFVI to use CC ZP 1.2.1