### PR TITLE
(5.1.x) Update LinuxMonitor ZenPack: 2.0.0 to 2.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -237,7 +237,7 @@
         },
         "zenpacks/ZenPacks.zenoss.LinuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.LinuxMonitor",
-            "ref": "2.0.0"
+            "ref": "2.0.1"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.ZenDeviceACL": {
             "repo": "zenoss/ZenPacks.zenoss.ZenDeviceACL2",


### PR DESCRIPTION
Changes from 2.0.0 to 2.0.1:

- Fix invalid event class in filesystem threshold.

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.0.0...2.0.1