### PR TITLE
(5.1.x) Update CiscoUCS ZenPack: 2.4.0 to 2.4.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -87,7 +87,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoUCS": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoUCS",
-            "ref": "2.4.0"
+            "ref": "2.4.3"
         },
         "zenpacks/ZenPacks.zenoss.FtpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.FtpMonitor",


### PR DESCRIPTION
Changes from 2.4.0 to 2.4.3:

- Optimization improvements for UCS Layer2 Linkable components. (ZEN-19856)
- Status map for storageLocalDisk has been updated with JBOD and Global Hot Spare drive states. (ZEN-22829)
- Fix for all CIMC fault events occuring in August 2014. (ZEN-23438)
- Fix for undefined componentType variable. (ZEN-23459)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.4.0...2.4.3