### PR TITLE
(5.1.x) Update LinuxMonitor ZenPack: 2.0.1 to 2.0.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -237,7 +237,7 @@
         },
         "zenpacks/ZenPacks.zenoss.LinuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.LinuxMonitor",
-            "ref": "2.0.1"
+            "ref": "2.0.2"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.ZenDeviceACL": {
             "repo": "zenoss/ZenPacks.zenoss.ZenDeviceACL2",


### PR DESCRIPTION
Changes from 2.0.1 to 2.0.2:

- Added property to ignore unmounted hard disks
- Improve 1.x to 2.x migration time. (ZEN-24024)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.0.1...2.0.2