### PR TITLE
(5.1.x) Update Microsoft.Windows ZenPack: 2.5.12 to 2.6.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -71,7 +71,7 @@
         },
         "zenpacks/ZenPacks.zenoss.Microsoft.Windows": {
             "repo": "zenoss/ZenPacks.zenoss.Microsoft.Windows",
-            "ref": "2.5.12"
+            "ref": "2.6.1"
         },
         "core": {
             "repo": "zenoss/zenoss-prodbin",


### PR DESCRIPTION
Changes from 2.5.12 to 2.6.1:

- Enabled the use of the Infrastructure -> Windows Services page
- Enabled domain authentication without the need for DNS
- Added ability to dump results from plugins for troubleshooting
- Converted to use zenpacklib
- Document Microsoft Windows Event Log Monitoring Returns Information Events (ZEN-22904)
- Fix zWinRMServerName not resolving properly on remote collector (ZEN-22880)
- Fix WinRM ZP Error about concurrent shells doesn't close when not reoccuring (ZEN-23010)
- Fix Latest version of WinRM pack (2.5.12) causes "AttributeError: in_exclusions" tracebacks (ZEN-23063)
- Fix WinRM Interface modeler does not account for HP NIC naming scheme (ZEN-20762)
- Fix WinRM monitoring does not emit message for expired password (ZEN-23183)
- Fix Windows kinit: Internal credentials cache error while storing credentials while getting initial credentials (ZEN-23238)
- Fix MSSQL Queries wrong database for metric (ZEN-23228)
- Fix Windows Service shows 'Up' when down if event class modified (ZEN-19615)
- Fix Windows Installed on UCS shows 2 interfaces where there's only 1 (ZEN-23379)
- Fix Windows ZenPack, doesn't send Datasource fields in 'cmd' to Parsers (ZEN-23739)
- Fix Windows Zenpack Impact relationships are inconsistent (ZEN-18648)
- Fix WinRMPing datasource should be disabled by default (ZEN-23517)
- Fix Copy Override of Windows template breaks EventLogDataSource query attribute (ZEN-23157)
- Fix Microsoft Windows ZenPack doesn't work with HyperV pack (ZEN-23967)
- Fix Microsoft Windows:  no collection when Processes are modeled (ZEN-24010)
- Fix Editing a Windows Service (WinService) Locks Up Zope and Times Out (ZEN-23827)

https://github.com/zenoss/ZenPacks.zenoss.Microsoft.Windows/compare/2.5.12...2.6.1