### PR TITLE
(5.1.x) Update vSphere ZenPack: 3.4.0 to 3.4.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -79,7 +79,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.vSphere": {
             "repo": "zenoss/ZenPacks.zenoss.vSphere",
-            "ref": "3.4.0"
+            "ref": "3.4.1"
         },
         "zenpacks/ZenPacks.zenoss.vCloud": {
             "repo": "zenoss/ZenPacks.zenoss.vCloud",


### PR DESCRIPTION
Changes from 3.4.0 to 3.4.1:

- Support multiple --query options in vsphere_queryperf tool
- Improved component grid performance with Zenoss 5.1.4+
- Use epoll reactor in zenvsphere to support >1024 descriptors.
- Fix off-by-one in chunk size calculation (ZEN-22805)
- Monitor ESX host preparation for NSX networking (ZEN-21157)
- Remove Dynamic View component from navigation, since it is not fully supported (ZEN-16277)

https://github.com/zenoss/ZenPacks.zenoss.vSphere/compare/3.4.0...3.4.1