### PR TITLE
(5.1.x) Remove EnterpriseLinux

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -145,10 +145,6 @@
             "repo": "zenoss/ZenPacks.zenoss.MySqlMonitor",
             "ref": "3.0.7"
         },
-        "enterprise_zenpacks/ZenPacks.zenoss.EnterpriseLinux": {
-            "repo": "zenoss/ZenPacks.zenoss.EnterpriseLinux",
-            "ref": "1.4.0"
-        },
         "zenpacks/ZenPacks.zenoss.HttpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.HttpMonitor",
             "ref": "2.1.0"


### PR DESCRIPTION
LinuxMonitor 2.0.0 deprecated EnterpriseLinux. So it's no longer
necessary. On top of that, by having EnterpriseLinux 1.4.0 installed
after LinuxMonitor we end up with badly-merged Linux templates.

Refs ZEN-24385.