### PR TITLE
(5.1.x) Update AixMonitor ZenPack: 2.2.1 to 2.2.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -273,7 +273,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.AixMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.AixMonitor",
-            "ref": "2.2.1"
+            "ref": "2.2.2"
         },
         "zproxy": {
             "repo": "zenoss/zproxy",


### PR DESCRIPTION
Changes from 2.2.1 to 2.2.2:

- Make event class /Status/OSProcess for process monitoring (ZEN-21999)
- Add zCredentialsZProperties: zCommandUsername & zCommandPassword
- Add mem__pct and fs__pct datapoint aliases (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.AixMonitor/compare/2.2.1...2.2.2