### PR TITLE
(5.1.x) Update LinuxMonitor ZenPack: 2.0.3 to 2.0.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -237,7 +237,7 @@
         },
         "zenpacks/ZenPacks.zenoss.LinuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.LinuxMonitor",
-            "ref": "2.0.3"
+            "ref": "2.0.4"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.ZenDeviceACL": {
             "repo": "zenoss/ZenPacks.zenoss.ZenDeviceACL2",


### PR DESCRIPTION
Changes from 2.0.3 to 2.0.4:

- Fix "unimplemented" SSH error on 4.2.5 SP709. (ZEN-23392)

https://github.com/zenoss/ZenPacks.zenoss.LinuxMonitor/compare/2.0.3...2.0.4