### PR TITLE
(5.1.x) Update BigIpMonitor ZenPack: 2.7.0 to 2.7.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.BigIpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.BigIpMonitor",
-            "ref": "2.7.0"
+            "ref": "2.7.1"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.EnterpriseSkin": {
             "repo": "zenoss/ZenPacks.zenoss.EnterpriseSkin",


### PR DESCRIPTION
Changes from 2.7.0 to 2.7.1:

- Convert load balancer port speed from megabits to bits
- Add datapoint aliases: mem__pct, in__pct, out__pct (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.BigIpMonitor/compare/2.7.0...2.7.1