### PR TITLE
(5.1.x) Update CheckPointMonitor ZenPack: 2.0.0 to 2.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -193,7 +193,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CheckPointMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.CheckPointMonitor",
-            "ref": "2.0.0"
+            "ref": "2.0.1"
         },
         "zenpacks/ZenPacks.zenoss.Dashboard": {
             "repo": "zenoss/ZenPacks.zenoss.Dashboard",


### PR DESCRIPTION
Changes from 2.0.0 to 2.0.1:

- Add common datapoint aliases. (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.CheckPointMonitor/compare/2.0.0...2.0.1