### PR TITLE
(5.1.x) Update CiscoMonitor ZenPack: 5.7.0 to 5.7.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoMonitor",
-            "ref": "5.7.0"
+            "ref": "5.7.2"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.MultiRealmIP": {
             "repo": "zenoss/ZenPacks.zenoss.MultiRealmIP",


### PR DESCRIPTION
Changes from 5.7.0 to 5.7.2:

- Fix StatCountInUse and StatCountPeak OID's. (ZEN-12336)
- Fix isProjection template copying error. (ZEN-23332)
- Set event class mapping sequences to 1000. (ZEN-23103)
- Fix ciscoEnvMonSuppStatusChangeNotif trap handler. (ZEN-24123)
- Fix ObjectNotFound zones modeling error
- Fix broken "|" eventKey on NX-API events. (ZEN-21247)
- Add common datapoint aliases. (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.CiscoMonitor/compare/5.7.0...5.7.2