### PR TITLE
(5.1.x) Update HpuxMonitor ZenPack: 2.0.0 to 2.0.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -163,7 +163,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.HpuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.HpuxMonitor",
-            "ref": "2.0.0"
+            "ref": "2.0.1"
         },
         "zenpacks/ZenPacks.zenoss.DigMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.DigMonitor",


### PR DESCRIPTION
Changes from 2.0.0 to 2.0.1:

- Fix modeling "ValueError" when swap volumes are disabled (ZEN-23286)
- Add common datapoint aliases (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.HpuxMonitor/compare/2.0.0...2.0.1