### PR TITLE
(5.1.x) Update NetScreenMonitor ZenPack: 2.2.0 to 2.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -131,7 +131,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.NetScreenMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.NetScreenMonitor",
-            "ref": "2.2.0"
+            "ref": "2.2.1"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.PropertyMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.PropertyMonitor",


### PR DESCRIPTION
Changes from 2.2.0 to 2.2.1:

- Add total memory modeling
- Change free memory threshold from 524288 bytes to 10% of total
- Add common datapoint aliases (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.NetScreenMonitor/compare/2.2.0...2.2.1