### PR TITLE
(5.1.x) Update SolarisMonitor ZenPack: 2.4.1 to 2.4.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -159,7 +159,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.SolarisMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.SolarisMonitor",
-            "ref": "2.4.1"
+            "ref": "2.4.2"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.HpuxMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.HpuxMonitor",


### PR DESCRIPTION
Changes from 2.4.1 to 2.4.2:

- Fix process monitoring event class and threshold (ZEN-21999)
- Fix for handling of empty zone status output
- Add common datapoint aliases (ZEN-24619)

https://github.com/zenoss/ZenPacks.zenoss.SolarisMonitor/compare/2.4.1...2.4.2