### PR TITLE
Update ZenSQLTx ZenPack: 2.6.3 to 2.6.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.ZenSQLTx": {
             "repo": "zenoss/ZenPacks.zenoss.ZenSQLTx",
-            "ref": "2.6.3"
+            "ref": "2.6.4"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.AdvancedSearch": {
             "repo": "zenoss/ZenPacks.zenoss.AdvancedSearch",


### PR DESCRIPTION
Changes from 2.6.3 to 2.6.4:

- Fix broken "timeout" field in SQL datasource edit dialog (ZEN-22955)
- Make SQL libraries importable by other ZenPacks (ZEN-23722)

https://github.com/zenoss/ZenPacks.zenoss.ZenSQLTx/compare/2.6.3...2.6.4