### PR TITLE
ZEN-24142: add zControlCenterPort property in UI when adding CC device

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -103,7 +103,7 @@
         },
         "zenpacks/ZenPacks.zenoss.ControlCenter": {
             "repo": "zenoss/ZenPacks.zenoss.ControlCenter",
-            "ref": "1.2.4"
+            "ref": "support/5.1.x"
         },
         "enterprise_zenpacks/ZenPacks.zenoss.DynamicView": {
             "repo": "zenoss/ZenPacks.zenoss.DynamicView",
@@ -337,7 +337,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.UCSXSkin": {
             "repo": "zenoss/ZenPacks.zenoss.UCSXSkin",
-            "ref": "2.1.7"
+            "ref": "develop"
         },
         "zenpacks/ZenPacks.zenoss.InstalledTemplatesReport": {
             "repo": "zenoss/ZenPacks.zenoss.InstalledTemplatesReport",


### PR DESCRIPTION
If CC is running on a non-standard port, the new CC device will
fail to monitor until you manually edit the property.
On the 'Add Infrastructure' page add field for Port when adding
new CC device.