### PR TITLE
Update NetAppMonitor ZenPack: 3.3.2 to 3.4.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -217,7 +217,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.NetAppMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.NetAppMonitor",
-            "ref": "3.3.2"
+            "ref": "3.4.2"
         },
         "metric-service": {
             "repo": "zenoss/query",


### PR DESCRIPTION
Changes from 3.3.2 to 3.4.2:

- Add support 9.0(C-Mode) ONTAP API version.
- Add Port component
- Add status monitoring for "vServer" and "Disk Shelf" components
- Fix ZEN-21557 (attribute error during modeling and monitoring)
- Fix ZEN-22440 (UTF8 monitoring issue)
- Fix ZEN-18846 (recursion error on a large number of records)
- Fix issue with negative scale for graphs
- Fix ZEN-21145 (fails to upgrade earlier version)
- Fix performance issue during modeling NFS Client components
- Fix modeling operational status and speed properties for virtual Interface components

https://github.com/zenoss/ZenPacks.zenoss.NetAppMonitor/compare/3.3.2...3.4.2

Fixes ZEN-26328.