### PR TITLE
Update CiscoUCS ZenPack: 2.5.2 to 2.5.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -87,7 +87,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoUCS": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoUCS",
-            "ref": "2.5.2"
+            "ref": "2.5.4"
         },
         "zenpacks/ZenPacks.zenoss.FtpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.FtpMonitor",


### PR DESCRIPTION
Changes from 2.5.2 to 2.5.4:

- Fix collection stall caused by interrupted connectivity. (ZPS-503)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.5.2...2.5.4