### PR TITLE
Update CiscoUCS ZenPack: 2.5.4 to 2.5.5

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -87,7 +87,7 @@
         },
         "enterprise_zenpacks/ZenPacks.zenoss.CiscoUCS": {
             "repo": "zenoss/ZenPacks.zenoss.CiscoUCS",
-            "ref": "2.5.4"
+            "ref": "2.5.5"
         },
         "zenpacks/ZenPacks.zenoss.FtpMonitor": {
             "repo": "zenoss/ZenPacks.zenoss.FtpMonitor",


### PR DESCRIPTION
Changes from 2.5.4 to 2.5.5:

- Fix warnings in modeling results. (ZPS-645)
- Fix CIMC "Maximum sessions reached" error. (ZPS-227)

https://github.com/zenoss/ZenPacks.zenoss.CiscoUCS/compare/2.5.4...2.5.5